### PR TITLE
Define HOST_CROSS_COMPILE properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,12 @@ Build Instructions
 
 4. Define the toolchains and environment variables:
 
-        export HOST_CROSS_COMPILE=$PWD/../toolchains/aarch64/bin/aarch64-linux-gnu-
+	If normal world user space is 64-bit:<BR>
+	`export HOST_CROSS_COMPILE=$PWD/../toolchains/aarch64/bin/aarch64-linux-gnu-`
+
+	If normal world user space is 32-bit:<BR>
+	`export HOST_CROSS_COMPILE=$PWD/../toolchains/aarch32/bin/arm-linux-gnueabihf-`
+
         export TA_CROSS_COMPILE=$PWD/../toolchains/aarch32/bin/arm-linux-gnueabihf-
         export TEEC_EXPORT=$PWD/../optee_client/out/export
         export TA_DEV_KIT_DIR=$PWD/../optee_os/out/arm/export-ta_arm32


### PR DESCRIPTION
export HOST_CROSS_COMPILE based on 32- or 64-bit normal world user space

Signed-off-by: Victor Chong <victor.chong@linaro.org>